### PR TITLE
Removing "tabs" permission (firefox)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "description": "__MSG_extDescription__",
   "manifest_version": 2,
   "name": "__MSG_extName__",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "homepage_url": "https://github.com/ettoolong/PopupWindow",
   "icons": {
     "16": "icon/icon.svg",
@@ -26,7 +26,6 @@
   },
   "permissions": [
     "storage",
-    "tabs",
     "contextMenus"
   ],
   "browser_action": {


### PR DESCRIPTION
According to the documentation, `tabs` permission is only needed when reading URL, title or favicon from a tab. None of this is required for this extension, so this permission can be safely removed. After this change, the browser will tell the user this extension doesn't need any special permission.

If this extension ever needs such kind of privilege, it should instead declare `activeTab` permission, that grants extra access only to the current tab and only when the extension is used.

* https://developer.chrome.com/extensions/windows
* https://developer.chrome.com/extensions/tabs
* https://developer.chrome.com/extensions/activeTab
* https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs
* https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activeTab_permission

Bonus: for convenience, I've also bumped the version number to 0.1.0.

This commit is the firefox version of the pull-request https://github.com/ettoolong/PopupWindow/pull/20

Sidenote: it would be nice to merge both firefox and chrome codebases into a single branch.